### PR TITLE
Update URL from airhornbot.com to airhorn.solutions

### DIFF
--- a/cmd/bot/bot.go
+++ b/cmd/bot/bot.go
@@ -457,7 +457,7 @@ func playSound(play *Play, vc *discordgo.VoiceConnection) (err error) {
 
 func onReady(s *discordgo.Session, event *discordgo.Ready) {
 	log.Info("Recieved READY payload")
-	s.UpdateStatus(0, "airhornbot.com")
+	s.UpdateStatus(0, "airhorn.solutions")
 }
 
 func onGuildCreate(s *discordgo.Session, event *discordgo.GuildCreate) {

--- a/cmd/webserver/web.go
+++ b/cmd/webserver/web.go
@@ -375,7 +375,7 @@ func main() {
 		ClientSecret: *ClientSecret,
 		Scopes:       []string{"bot", "identify"},
 		Endpoint:     endpoint,
-		RedirectURL:  "https://airhornbot.com/callback",
+		RedirectURL:  "https://airhorn.solutions/callback",
 	}
 
 	server()

--- a/static/src/index.html
+++ b/static/src/index.html
@@ -4,7 +4,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
   <meta property="title" content="!airhorn" />
   <meta property="url" content="https://airhorn.solutions" />
-  <meta property="url" content="https://airhornbot.com" />
   <meta property="description" content="A Discord bot with live statistics that makes airhorn sounds BEEP BOOP." />
   <meta property="site_name" content="Airhorn Solutions" />
   <meta property="locale" content="en_US" />


### PR DESCRIPTION
I noticed when adding this bot to a discord server that it displays it's playing airhornbot.com, the old url. This pull request simply updates any references from the old url to the new url.